### PR TITLE
(同じレベル内での隣接ノードを考慮しない)cuthill-mckee法の実装を行いました。(apply_vs2017から生やしちゃった版)

### DIFF
--- a/Abmc/Abmc.hpp
+++ b/Abmc/Abmc.hpp
@@ -547,19 +547,19 @@ static void CuthillMckee(const Matrix& A, const Vector& b, const Vector& expect)
 			const auto levelI = level[i];
 			const auto offset = A.index1_data()[i];
 			const auto count = A.index1_data()[i+1] - offset; // count
+			maxLevel = levelI + 1;
 			for (auto idx = decltype(count)(0); idx < count; idx++)
 			{
 				const auto j = A.index2_data()[offset + idx];
 				// 隣接点のlevelが未割り当て
 				if (level[j] == INVALID_LEVEL) {
-					level[j] = levelI + 1;
+					level[j] = maxLevel;
 					que.push(j);
-					// level[j]は常にmaxLevelを指す
-					maxLevel = level[j];
 				}
 			}
 		}
 	}
+	maxLevel--; //最後のqueが読まれたタイミングでmaxLevelが1大きくなるためここで減らす
 
 	auto row = std::make_unique<Index[]>(N); // 並び替え後の行番号→元の行番号の変換表
 	auto offset = std::make_unique<Index[]>(maxLevel+1); // 各レベルの開始番号

--- a/Abmc/Abmc.hpp
+++ b/Abmc/Abmc.hpp
@@ -544,6 +544,7 @@ static void CuthillMckee(const Matrix& A, const Vector& b, const Vector& expect)
 		for (; !que.empty(); que.pop())
 		{
 			auto i = que.front();
+			const auto levelI = level[i];
 			const auto offset = A.index1_data()[i];
 			const auto count = A.index1_data()[i+1] - offset; // count
 			for (auto idx = decltype(count)(0); idx < count; idx++)
@@ -551,7 +552,7 @@ static void CuthillMckee(const Matrix& A, const Vector& b, const Vector& expect)
 				const auto j = A.index2_data()[offset + idx];
 				// 隣接点のlevelが未割り当て
 				if (level[j] == INVALID_LEVEL) {
-					level[j] = level[i] + 1;
+					level[j] = levelI + 1;
 					que.push(j);
 					// level[j]は常にmaxLevelを指す
 					maxLevel = level[j];

--- a/Abmc/Abmc.hpp
+++ b/Abmc/Abmc.hpp
@@ -504,6 +504,7 @@ static void CuthillMckee(const Matrix& A, const Vector& b, const Vector& expect)
 {
 	constexpr auto INVALID_LEVEL = Level(0);
 	auto level = std::make_unique<Level[]>(N);
+	std::fill(level.get(), level.get() + N, INVALID_LEVEL);
 	auto degreeIndex = std::make_unique<std::pair<Index, Index>[]>(N); // degree, index
 	auto degree = std::make_unique<Index[]>(N);
 

--- a/Abmc/Abmc.hpp
+++ b/Abmc/Abmc.hpp
@@ -540,7 +540,7 @@ static void CuthillMckee(const Matrix& A, const Vector& b, const Vector& expect)
 		level[minDegreeIndex] = maxLevel + 1;
 		maxLevel = level[minDegreeIndex];
 
-		// cur: 今見ているノード
+		// cur: 今見ている点
 		for (; !que.empty(); que.pop())
 		{
 			auto i = que.front();
@@ -549,7 +549,7 @@ static void CuthillMckee(const Matrix& A, const Vector& b, const Vector& expect)
 			for (auto idx = decltype(count)(0); idx < count; idx++)
 			{
 				const auto j = A.index2_data()[offset + idx];
-				// 隣接ノードのlevelが未割り当て
+				// 隣接点のlevelが未割り当て
 				if (level[j] == INVALID_LEVEL) {
 					level[j] = level[i] + 1;
 					que.push(j);

--- a/Abmc/Abmc.hpp
+++ b/Abmc/Abmc.hpp
@@ -501,8 +501,8 @@ static void CuthillMckee(const Matrix& A, const Vector& b, const Vector& expect)
 				}
 			}
 		}
+		maxLevel--; //最後のqueが読まれたタイミングでmaxLevelが1大きくなるためここで減らす
 	}
-	maxLevel--; //最後のqueが読まれたタイミングでmaxLevelが1大きくなるためここで減らす
 
 	auto row = std::make_unique<Index[]>(N); // 並び替え後の行番号→元の行番号の変換表
 	auto offset = std::make_unique<Index[]>(maxLevel+1); // 各レベルの開始番号

--- a/Abmc/Abmc.hpp
+++ b/Abmc/Abmc.hpp
@@ -541,9 +541,9 @@ static void CuthillMckee(const Matrix& A, const Vector& b, const Vector& expect)
 		maxLevel = level[minDegreeIndex];
 
 		// cur: 今見ているノード
-		for (auto i = que.front(); !que.empty(); que.pop())
+		for (; !que.empty(); que.pop())
 		{
-			i = que.front();
+			auto i = que.front();
 			const auto offset = A.index1_data()[i];
 			const auto count = A.index1_data()[i+1] - offset; // count
 			for (auto idx = decltype(count)(0); idx < count; idx++)

--- a/Abmc/Abmc.hpp
+++ b/Abmc/Abmc.hpp
@@ -444,9 +444,9 @@ static void AlgebraicBlockMultiColoring(const Matrix& A, const Vector& b, const 
 
 static void CreateRowForCuthillMckee(Index row[], Index offset[], const Level level[], const Level degree[])
 {
-	// 色番号の小さい順に並び替え
-	// ・同じ色の場合はブロック番号の小さい順
-	// ・同じブロックなら行番号の小さい順
+	// レベルの小さい順に並び替え
+	// ・同じレベルの場合は次数の小さい順
+	// ・同じ次数なら行番号の小さい順
 	auto data = std::make_unique<std::tuple<Level, Index, Index>[]>(N); // Level, degree, index
 	for(auto i = decltype(N)(0); i < N; i++)
 	{
@@ -455,17 +455,17 @@ static void CreateRowForCuthillMckee(Index row[], Index offset[], const Level le
 	std::sort(data.get(), data.get() + N, [](auto left, auto right)
 	{
 		{
-			const auto leftColor = std::get<0>(left); const auto rightColor = std::get<0>(right);
-			if(leftColor != rightColor)
+			const auto leftLevel = std::get<0>(left); const auto rightLevel = std::get<0>(right);
+			if(leftLevel != rightLevel)
 			{
-				return leftColor < rightColor;
+				return leftLevel < rightLevel;
 			}
 		}
 		{
-			const auto leftBlock = std::get<1>(left); const auto rightBlock = std::get<1>(right);
-			if(leftBlock != rightBlock)
+			const auto leftDegree = std::get<1>(left); const auto rightDegree = std::get<1>(right);
+			if(leftDegree != rightDegree)
 			{
-				return leftBlock < rightBlock;
+				return leftDegree < rightDegree;
 			}
 		}
 		{
@@ -488,9 +488,9 @@ static void CreateRowForCuthillMckee(Index row[], Index offset[], const Level le
 		offset[0] = 0;
 		for(auto i = decltype(N)(1); i < N; i++)
 		{
-			const auto prevBlock = std::get<0>(data[i - 1]); // level
-			const auto thisBlock = std::get<0>(data[i]); // level
-			if(prevBlock != thisBlock)
+			const auto prevLevel = std::get<0>(data[i - 1]);
+			const auto thisLevel = std::get<0>(data[i]);
+			if(prevLevel != thisLevel)
 			{
 				offset[levelCount] = i;
 				levelCount++;
@@ -561,7 +561,7 @@ static void CuthillMckee(const Matrix& A, const Vector& b, const Vector& expect)
 	}
 
 	auto row = std::make_unique<Index[]>(N); // 並び替え後の行番号→元の行番号の変換表
-	auto offset = std::make_unique<Index[]>(maxLevel+1); // 各色の開始番号
+	auto offset = std::make_unique<Index[]>(maxLevel+1); // 各レベルの開始番号
 	CreateRowForCuthillMckee(row.get(), offset.get(), level.get(), degree.get());
 	GaussSeidelForCuthillMckee(A,b,expect, row.get(), offset.get(), maxLevel);
 	SymmetryGaussSeidelForCuthillMckee(A,b,expect, row.get(), offset.get(), maxLevel);

--- a/Abmc/Abmc.hpp
+++ b/Abmc/Abmc.hpp
@@ -533,7 +533,7 @@ static void CuthillMckee(const Matrix& A, const Vector& b, const Vector& expect)
 		// すべての点を探索し終えたら終了
 		if (minDegreeIndexItr == degreeIndex.get() + N) break;
 
-		auto minDegreeIndex = minDegreeIndexItr->second;
+		const auto minDegreeIndex = minDegreeIndexItr->second;
 
 		std::queue<Level> que;
 		que.push(minDegreeIndex);
@@ -543,7 +543,7 @@ static void CuthillMckee(const Matrix& A, const Vector& b, const Vector& expect)
 		// i: 今見ている点
 		for (; !que.empty(); que.pop())
 		{
-			auto i = que.front();
+			const auto i = que.front();
 			const auto levelI = level[i];
 			const auto offset = A.index1_data()[i];
 			const auto count = A.index1_data()[i+1] - offset; // count

--- a/Abmc/Abmc.hpp
+++ b/Abmc/Abmc.hpp
@@ -463,11 +463,11 @@ static void CuthillMckee(const Matrix& A, const Vector& b, const Vector& expect)
 	std::sort(degreeIndex.get(), degreeIndex.get() + N);
 	auto maxLevel = Level(0);
 
-	// 2. 幅優先探索 O(N)
+	// 点群が別れているときに、再度最小次数を探して幅優先探索をするためのループ O(N)
 	while (true)
 	{
 		// 探索済みではない次数が最小となるindexの探索
-		auto minDegreeIndexItr = std::find_if(degreeIndex.get(), degreeIndex.get() + N, [&level, INVALID_LEVEL](const auto& degIndex)
+		auto minDegreeIndexItr = std::find_if(degreeIndex.get(), degreeIndex.get() + N, [&level = static_cast<const std::unique_ptr<Level[]>&>(level), INVALID_LEVEL](const auto& degIndex)
 		{
 			return level[degIndex.second] == INVALID_LEVEL;
 		});
@@ -477,12 +477,13 @@ static void CuthillMckee(const Matrix& A, const Vector& b, const Vector& expect)
 
 		const auto minDegreeIndex = minDegreeIndexItr->second;
 
+		// 最小次数の点を初期探索点とする(最初に呼ばれたときはレベル1スタート)
 		std::queue<Level> que;
 		que.push(minDegreeIndex);
 		level[minDegreeIndex] = maxLevel + 1;
 		maxLevel = level[minDegreeIndex];
 
-		// i: 今見ている点
+		//幅優先探索
 		for (; !que.empty(); que.pop())
 		{
 			const auto i = que.front();

--- a/Abmc/Abmc.hpp
+++ b/Abmc/Abmc.hpp
@@ -565,7 +565,7 @@ static void CuthillMckee(const Matrix& A, const Vector& b, const Vector& expect)
 		auto offset = std::make_unique<Index[]>(maxLevel+1); // 各色の開始番号
 		CreateRowForCuthillMckee(row.get(), offset.get(), level.get(), degree.get());
 		GaussSeidelForCuthillMckee(A,b,expect, row.get(), offset.get(), maxLevel);
-		SymmetryGaussSeidelForCutHillMckee(A,b,expect, row.get(), offset.get(), maxLevel);
+		SymmetryGaussSeidelForCuthillMckee(A,b,expect, row.get(), offset.get(), maxLevel);
 	}
 }
 

--- a/Abmc/Abmc.hpp
+++ b/Abmc/Abmc.hpp
@@ -467,7 +467,7 @@ static void CuthillMckee(const Matrix& A, const Vector& b, const Vector& expect)
 	while (true)
 	{
 		// 探索済みではない次数が最小となるindexの探索
-		auto minDegreeIndexItr = std::find_if(degreeIndex.get(), degreeIndex.get() + N, [&level, &INVALID_LEVEL](const auto& degIndex)
+		auto minDegreeIndexItr = std::find_if(degreeIndex.get(), degreeIndex.get() + N, [&level, INVALID_LEVEL](const auto& degIndex)
 		{
 			return level[degIndex.second] == INVALID_LEVEL;
 		});

--- a/Abmc/Abmc.hpp
+++ b/Abmc/Abmc.hpp
@@ -525,19 +525,15 @@ static void CuthillMckee(const Matrix& A, const Vector& b, const Vector& expect)
 	while (true)
 	{
 		// 探索済みではない次数が最小となるindexの探索
-		auto minDegreeIndex = N + 1;
-		for (auto i = decltype(N)(0); i < N; i++)
+		auto minDegreeIndexItr = std::find_if(degreeIndex.get(), degreeIndex.get() + N, [&level, &INVALID_LEVEL](const auto& degIndex)
 		{
-			const auto index = degreeIndex[i].second;
-			if (level[index] == INVALID_LEVEL)
-			{
-				minDegreeIndex = index;
-				break;
-			}
-		}
+			return level[degIndex.second] == INVALID_LEVEL;
+		});
 
 		// すべての点を探索し終えたら終了
-		if (minDegreeIndex == N + 1) break;
+		if (minDegreeIndexItr == degreeIndex.get() + N) break;
+
+		auto minDegreeIndex = minDegreeIndexItr->second;
 
 		std::queue<Level> que;
 		que.push(minDegreeIndex);

--- a/Abmc/Abmc.hpp
+++ b/Abmc/Abmc.hpp
@@ -541,20 +541,20 @@ static void CuthillMckee(const Matrix& A, const Vector& b, const Vector& expect)
 		maxLevel = level[minDegreeIndex];
 
 		// cur: 今見ているノード
-		for (auto cur = que.front(); !que.empty(); que.pop())
+		for (auto i = que.front(); !que.empty(); que.pop())
 		{
-			cur = que.front();
-			const auto offset = A.index1_data()[cur];
-			const auto count = A.index1_data()[cur+1] - offset; // count
+			i = que.front();
+			const auto offset = A.index1_data()[i];
+			const auto count = A.index1_data()[i+1] - offset; // count
 			for (auto idx = decltype(count)(0); idx < count; idx++)
 			{
-				const auto tar = A.index2_data()[offset + idx];
+				const auto j = A.index2_data()[offset + idx];
 				// 隣接ノードのlevelが未割り当て
-				if (level[tar] == INVALID_LEVEL) {
-					level[tar] = level[cur] + 1;
-					que.push(tar);
+				if (level[j] == INVALID_LEVEL) {
+					level[j] = level[i] + 1;
+					que.push(j);
 					// level[tar]は常にmaxLevelを指す
-					maxLevel = level[tar];
+					maxLevel = level[j];
 				}
 			}
 		}

--- a/Abmc/Abmc.hpp
+++ b/Abmc/Abmc.hpp
@@ -512,7 +512,7 @@ static void CuthillMckee(const Matrix& A, const Vector& b, const Vector& expect)
 	for (auto i = decltype(N)(0); i < N; i++)
 	{
 		const auto offset = A.index1_data()[i];
-		const auto deg = A.index1_data()[i] - offset; // count
+		const auto deg = A.index1_data()[i+1] - offset; // count
 		degreeIndex[i] = std::make_pair(deg, i);
 		degree[i] = deg;
 	}

--- a/Abmc/Abmc.hpp
+++ b/Abmc/Abmc.hpp
@@ -540,7 +540,7 @@ static void CuthillMckee(const Matrix& A, const Vector& b, const Vector& expect)
 		level[minDegreeIndex] = maxLevel + 1;
 		maxLevel = level[minDegreeIndex];
 
-		// cur: 今見ている点
+		// i: 今見ている点
 		for (; !que.empty(); que.pop())
 		{
 			auto i = que.front();
@@ -553,7 +553,7 @@ static void CuthillMckee(const Matrix& A, const Vector& b, const Vector& expect)
 				if (level[j] == INVALID_LEVEL) {
 					level[j] = level[i] + 1;
 					que.push(j);
-					// level[tar]は常にmaxLevelを指す
+					// level[j]は常にmaxLevelを指す
 					maxLevel = level[j];
 				}
 			}

--- a/Abmc/Abmc.hpp
+++ b/Abmc/Abmc.hpp
@@ -508,7 +508,7 @@ static void CuthillMckee(const Matrix& A, const Vector& b, const Vector& expect)
 	auto degree = std::make_unique<Index[]>(N);
 
 	// 次数を求める
-	for (Index i = decltype(N)(0); i < N; i++)
+	for (auto i = decltype(N)(0); i < N; i++)
 	{
 		const auto offset = A.index1_data()[i];
 		const auto deg = A.index1_data()[i] - offset; // count
@@ -518,16 +518,16 @@ static void CuthillMckee(const Matrix& A, const Vector& b, const Vector& expect)
 
 	// 1. 最小次数を探す O(N)
 	std::sort(degreeIndex.get(), degreeIndex.get() + N);
-	Level maxLevel = Level(0);
+	auto maxLevel = Level(0);
 
 	// 2. 幅優先探索 O(N)
 	while (true)
 	{
 		// 探索済みではない次数が最小となるindexの探索
-		Index minDegreeIndex = N + 1;
-		for (Index i = decltype(N)(0); i < N; i++)
+		auto minDegreeIndex = N + 1;
+		for (auto i = decltype(N)(0); i < N; i++)
 		{
-			const Index index = degreeIndex[i].second;
+			const auto index = degreeIndex[i].second;
 			if (level[index] == INVALID_LEVEL)
 			{
 				minDegreeIndex = index;

--- a/Abmc/Abmc.hpp
+++ b/Abmc/Abmc.hpp
@@ -558,13 +558,13 @@ static void CuthillMckee(const Matrix& A, const Vector& b, const Vector& expect)
 				}
 			}
 		}
-
-		auto row = std::make_unique<Index[]>(N); // 並び替え後の行番号→元の行番号の変換表
-		auto offset = std::make_unique<Index[]>(maxLevel+1); // 各色の開始番号
-		CreateRowForCuthillMckee(row.get(), offset.get(), level.get(), degree.get());
-		GaussSeidelForCuthillMckee(A,b,expect, row.get(), offset.get(), maxLevel);
-		SymmetryGaussSeidelForCuthillMckee(A,b,expect, row.get(), offset.get(), maxLevel);
 	}
+
+	auto row = std::make_unique<Index[]>(N); // 並び替え後の行番号→元の行番号の変換表
+	auto offset = std::make_unique<Index[]>(maxLevel+1); // 各色の開始番号
+	CreateRowForCuthillMckee(row.get(), offset.get(), level.get(), degree.get());
+	GaussSeidelForCuthillMckee(A,b,expect, row.get(), offset.get(), maxLevel);
+	SymmetryGaussSeidelForCuthillMckee(A,b,expect, row.get(), offset.get(), maxLevel);
 }
 
 #endif

--- a/Abmc/Abmc.hpp
+++ b/Abmc/Abmc.hpp
@@ -510,7 +510,6 @@ static void CuthillMckee(const Matrix& A, const Vector& b, const Vector& expect)
 	// 次数を求める
 	for (Index i = decltype(N)(0); i < N; i++)
 	{
-		const Index index = degreeIndex[i].second;
 		const auto offset = A.index1_data()[i];
 		const auto deg = A.index1_data()[i] - offset; // count
 		degreeIndex[i] = std::make_pair(deg, i);

--- a/Abmc/Abmc.hpp
+++ b/Abmc/Abmc.hpp
@@ -541,7 +541,8 @@ static void CuthillMckee(const Matrix& A, const Vector& b, const Vector& expect)
 		maxLevel = level[minDegreeIndex];
 
 		// cur: 今見ているノード
-		for (auto cur = que.front(); !que.empty(); que.pop()) {
+		for (auto cur = que.front(); !que.empty(); que.pop())
+		{
 			cur = que.front();
 			const auto offset = A.index1_data()[cur];
 			const auto count = A.index1_data()[cur+1] - offset; // count

--- a/Abmc/Abmc.hpp
+++ b/Abmc/Abmc.hpp
@@ -442,7 +442,7 @@ static void AlgebraicBlockMultiColoring(const Matrix& A, const Vector& b, const 
 	SymmetryGaussSeidel(A, b, expect, row.get(), blockOffset.get(), offset.get(), colorCount);
 }
 
-static void CreateRowForCuthillMckee(Index row[], Index offset[], const Level level[], const Level degree[])
+static void CreateRowForCuthillMckee(Index row[], Index offset[], const Level level[], const Index degree[])
 {
 	// レベルの小さい順に並び替え
 	// ・同じレベルの場合は次数の小さい順

--- a/Abmc/SymGS.hpp
+++ b/Abmc/SymGS.hpp
@@ -162,6 +162,26 @@ static void GaussSeidel(const Matrix& A, const Vector& b, const Vector& expect,
 	});
 }
 
+// CutHill-Mckeeのガウスザイデル法
+static void GaussSeidelForCuthillMckee(const Matrix& A, const Vector& b, const Vector& expect,
+	const Index row[],
+	const Index offset[],
+	const Color levelConut)
+{
+	Solve("CutHill-Mckeeガウスザイデル法", expect, [&A, &b, &row, &offset, levelConut](Vector& x)
+	{
+		// 順
+		for (auto level = decltype(levelConut)(0); level < levelConut; level++)
+		{
+			for (auto idx = offset[level]; idx < offset[level + 1]; idx++)
+			{
+				const auto i = row[idx];
+				GaussSeidelMain(x, A, b, i);
+			}
+		}
+	});
+}
+
 // 対称ガウスザイデル法
 static void SymmetryGaussSeidel(const Matrix& A, const Vector& b, const Vector& expect)
 {
@@ -246,6 +266,36 @@ static void SymmetryGaussSeidel(const Matrix& A, const Vector& b, const Vector& 
 					const auto i = row[idx];
 					GaussSeidelMain(x, A, b, i);
 				}
+			}
+		}
+	});
+}
+
+// CutHill-Mckeeのガウスザイデル法
+static void SymmetryGaussSeidelForCutHillMckee(const Matrix& A, const Vector& b, const Vector& expect,
+	const Index row[],
+	const Index offset[],
+	const Level levelCount)
+{
+	Solve("CutHill-Mckee対称ガウスザイデル法", expect, [&A, &b, &row, &offset, levelCount](Vector& x)
+	{
+		// 順
+		for(auto level = decltype(levelCount)(0); level < levelCount; level++)
+		{
+			for(auto idx = offset[level]; idx < offset[level + 1]; idx++)
+			{
+				const auto i = row[idx];
+				GaussSeidelMain(x, A, b, i);
+			}
+		}
+
+		// 逆順
+		for(auto level = static_cast<std::make_signed_t<decltype(levelCount)>>(levelCount - 1); level > 0; level--)
+		{
+			for(auto idx = offset[level+1] - 1; idx >= offset[level]; idx--) // 隣接ノードの排除をしていないので、同じLevel内でも逆順にする必要がある。
+			{
+				const auto i = row[idx];
+				GaussSeidelMain(x, A, b, i);
 			}
 		}
 	});

--- a/Abmc/SymGS.hpp
+++ b/Abmc/SymGS.hpp
@@ -162,13 +162,13 @@ static void GaussSeidel(const Matrix& A, const Vector& b, const Vector& expect,
 	});
 }
 
-// CutHill-Mckeeのガウスザイデル法
+// Cuthill-Mckeeのガウスザイデル法
 static void GaussSeidelForCuthillMckee(const Matrix& A, const Vector& b, const Vector& expect,
 	const Index row[],
 	const Index offset[],
 	const Color levelConut)
 {
-	Solve("CutHill-Mckeeガウスザイデル法", expect, [&A, &b, &row, &offset, levelConut](Vector& x)
+	Solve("Cuthill-Mckeeガウスザイデル法", expect, [&A, &b, &row, &offset, levelConut](Vector& x)
 	{
 		// 順
 		for (auto level = decltype(levelConut)(0); level < levelConut; level++)
@@ -271,13 +271,13 @@ static void SymmetryGaussSeidel(const Matrix& A, const Vector& b, const Vector& 
 	});
 }
 
-// CutHill-Mckeeのガウスザイデル法
-static void SymmetryGaussSeidelForCutHillMckee(const Matrix& A, const Vector& b, const Vector& expect,
+// Cuthill-Mckeeのガウスザイデル法
+static void SymmetryGaussSeidelForCuthillMckee(const Matrix& A, const Vector& b, const Vector& expect,
 	const Index row[],
 	const Index offset[],
 	const Level levelCount)
 {
-	Solve("CutHill-Mckee対称ガウスザイデル法", expect, [&A, &b, &row, &offset, levelCount](Vector& x)
+	Solve("Cuthill-Mckee対称ガウスザイデル法", expect, [&A, &b, &row, &offset, levelCount](Vector& x)
 	{
 		// 順
 		for(auto level = decltype(levelCount)(0); level < levelCount; level++)

--- a/Abmc/common.hpp
+++ b/Abmc/common.hpp
@@ -12,5 +12,6 @@ using Vector = boost::numeric::ublas::vector<double>;
 using Index = std::remove_const_t<decltype(N)>;
 using Color = Index;
 using Block = Index;
+using Level = Index;
 
 #endif

--- a/Abmc/main.cpp
+++ b/Abmc/main.cpp
@@ -58,5 +58,8 @@ int main()
 	GeometicBlockMultiColoring<4>(A, b, expect); std::cout << "####################################" << std::endl;
 	AlgebraicBlockMultiColoring<4>(A, b, expect); std::cout << "####################################" << std::endl;
 
+	// Cuthill-Mckee
+	CuthillMckee(A, b, expect); std::cout << "####################################" << std::endl;
+
 	return 0;
 }


### PR DESCRIPTION
https://github.com/fixstars/AlgebraicBlockMulticolorOrdering/issues/1
こちらに書いてある実装方法で、まず隣接ノードを考慮しないcuthill-mckee法を実装しました。

並列化のためには、同じレベル内で隣接ノードを排除しなければなりませんが、現状それは実装していません。