### PR TITLE
同じレベル内での隣接点を排除するCuthill-Mckee法に改良

### DIFF
--- a/Abmc/Abmc.hpp
+++ b/Abmc/Abmc.hpp
@@ -486,7 +486,7 @@ static void CuthillMckee(const Matrix& A, const Vector& b, const Vector& expect)
 
 		//幅優先探索
 		std::set<Index> adjacentPoint; //同じレベル内の隣接点をメモ
-		Level prevLevel = 0; // 一つ前の探索の時点でのレベル
+		Level prevLevel = maxLevel; // 一つ前の探索の時点でのレベル
 		for (; !que.empty(); que.pop())
 		{
 			const auto i = que.front();

--- a/Abmc/Abmc.hpp
+++ b/Abmc/Abmc.hpp
@@ -511,7 +511,7 @@ static void CuthillMckee(const Matrix& A, const Vector& b, const Vector& expect)
 					// 隣接点の隣接点用のoffsetとcount
 					const auto offsetJ = A.index1_data()[j];
 					const auto countJ = A.index1_data()[j+1] - offsetJ;
-					for (int jdx = decltype(countJ)(0); jdx < countJ; jdx++)
+					for (auto jdx = decltype(countJ)(0); jdx < countJ; jdx++)
 					{
 						// jj: 隣接点の隣接点
 						const auto jj = A.index2_data()[offsetJ + jdx];

--- a/Abmc/Abmc.hpp
+++ b/Abmc/Abmc.hpp
@@ -495,6 +495,7 @@ static void CuthillMckee(const Matrix& A, const Vector& b, const Vector& expect)
 			const auto offset = A.index1_data()[i];
 			const auto count = A.index1_data()[i+1] - offset; // count
 			maxLevel = levelI + 1;
+			// 新しいレベルの探索になるため、隣接点をクリア
 			if (prevLevel < maxLevel)
 			{
 				adjacentPoint.clear();

--- a/Abmc/Abmc.hpp
+++ b/Abmc/Abmc.hpp
@@ -490,7 +490,6 @@ static void CuthillMckee(const Matrix& A, const Vector& b, const Vector& expect)
 		for (; !que.empty(); que.pop())
 		{
 			const auto i = que.front();
-			std::cout << i << std::endl;
 			const auto levelI = level[i];
 			const auto offset = A.index1_data()[i];
 			const auto count = A.index1_data()[i+1] - offset; // count
@@ -508,7 +507,6 @@ static void CuthillMckee(const Matrix& A, const Vector& b, const Vector& expect)
 					level[j] = maxLevel;
 					prevLevel = maxLevel;
 					que.push(j);
-					std::cout << j << std::endl;
 
 					// 隣接点の隣接点用のoffsetとcount
 					const auto offsetJ = A.index1_data()[j];

--- a/Abmc/Abmc.hpp
+++ b/Abmc/Abmc.hpp
@@ -585,6 +585,7 @@ static void CuthillMckee(const Matrix& A, const Vector& b, const Vector& expect)
 			offset[levelCount] = N;
 		}
 	}
+	OutputResult("同じレベル内の隣接点を除外するCuthill-Mckee法", A, row.get());
 	GaussSeidelForCuthillMckee(A,b,expect, row.get(), offset.get(), maxLevel);
 	SymmetryGaussSeidelForCuthillMckee(A,b,expect, row.get(), offset.get(), maxLevel);
 }

--- a/Abmc/Abmc.hpp
+++ b/Abmc/Abmc.hpp
@@ -503,7 +503,7 @@ static void CuthillMckee(const Matrix& A, const Vector& b, const Vector& expect)
 			for (auto idx = decltype(count)(0); idx < count; idx++)
 			{
 				const auto j = A.index2_data()[offset + idx];
-				// 隣接点のlevelが未割り当て かつ どの隣接点にも属していない
+				// 隣接点の levelが未割り当て かつ 同じレベルのすでに割り当てられる点に隣接していない
 				if (level[j] == INVALID_LEVEL && adjacentPoint.find(j) == adjacentPoint.end()) {
 					level[j] = maxLevel;
 					prevLevel = maxLevel;

--- a/Abmc/Abmc.hpp
+++ b/Abmc/Abmc.hpp
@@ -515,7 +515,7 @@ static void CuthillMckee(const Matrix& A, const Vector& b, const Vector& expect)
 					{
 						// jj: 隣接点の隣接点
 						const auto jj = A.index2_data()[offsetJ + jdx];
-						// jjが未探索(探索済みのIndexを登録する意味はない)
+						// jjが未探索(探索済みのIndexを無視する意味はない)
 						if (level[jj] == INVALID_LEVEL) {
 							adjacentPoint.insert(jj);
 						}

--- a/Abmc/Abmc.hpp
+++ b/Abmc/Abmc.hpp
@@ -486,7 +486,7 @@ static void CuthillMckee(const Matrix& A, const Vector& b, const Vector& expect)
 
 		//幅優先探索
 		std::set<Index> adjacentPoint; //同じレベル内の隣接点をメモ
-		Level prevLevel = maxLevel; // 一つ前に代入したレベル
+		auto prevLevel = maxLevel; // 一つ前に代入したレベル
 		for (; !que.empty(); que.pop())
 		{
 			const auto i = que.front();

--- a/Abmc/Abmc.hpp
+++ b/Abmc/Abmc.hpp
@@ -486,7 +486,7 @@ static void CuthillMckee(const Matrix& A, const Vector& b, const Vector& expect)
 
 		//幅優先探索
 		std::set<Index> adjacentPoint; //同じレベル内の隣接点をメモ
-		Level prevLevel = maxLevel; // 一つ前の探索の時点でのレベル
+		Level prevLevel = maxLevel; // 一つ前に代入したレベル
 		for (; !que.empty(); que.pop())
 		{
 			const auto i = que.front();

--- a/Abmc/Abmc.hpp
+++ b/Abmc/Abmc.hpp
@@ -494,7 +494,7 @@ static void CuthillMckee(const Matrix& A, const Vector& b, const Vector& expect)
 			const auto offset = A.index1_data()[i];
 			const auto count = A.index1_data()[i+1] - offset; // count
 			maxLevel = levelI + 1;
-			// 新しいレベルの探索になるため、隣接点をクリア
+			// 新しいレベルの探索になるため、無視する隣接点をクリア
 			if (prevLevel < maxLevel)
 			{
 				adjacentPoint.clear();

--- a/Abmc/SymGS.hpp
+++ b/Abmc/SymGS.hpp
@@ -292,7 +292,7 @@ static void SymmetryGaussSeidelForCuthillMckee(const Matrix& A, const Vector& b,
 		// 逆順
 		for(auto level = static_cast<std::make_signed_t<decltype(levelCount)>>(levelCount - 1); level > 0; level--)
 		{
-			for(auto idx = offset[level+1] - 1; idx >= offset[level]; idx--) // 隣接ノードの排除をしていないので、同じLevel内でも逆順にする必要がある。
+			for(auto idx = offset[level]; idx < offset[level+1]; idx++) // 同じレベル内では、依存関係はないのでここは逆順にする必要がない
 			{
 				const auto i = row[idx];
 				GaussSeidelMain(x, A, b, i);


### PR DESCRIPTION
# レベル付
行列をx,y表面上で表現したときのレベル(隣接していないことの確認)
```
01 02 03 04 05 06 07 08 
03 04 05 06 07 08 09 10 
05 06 07 08 09 10 11 12 
07 08 09 10 11 12 13 14 
09 10 11 12 13 14 15 16 
11 12 13 14 15 16 17 18 
13 14 15 16 17 18 19 20 
15 16 17 18 19 20 21 22 
```
# 収束の様子

## ガウスザイデル
完全に一致
```
反復回数, ガウスザイデル, cuthill-mckee ガウスザイデル
0, 641281.0, 641281.0, 
1, 375384.0, 375384.0, 
2, 254367.0, 254367.0, 
3, 177790.0, 177790.0, 
4, 125362.0, 125362.0, 
5, 88555.7, 88555.7, 
6, 62506.4, 62506.4, 
7, 44032.8, 44032.8, 
8, 30938.8, 30938.8, 
9, 21679.2, 21679.2, 
10, 15152.3, 15152.3, 
11, 10567.2, 10567.2, 
12, 7356.22, 7356.22, 
13, 5113.52, 5113.52, 
14, 3550.53, 3550.53, 
15, 2463.12, 2463.12, 
16, 1707.6, 1707.6, 
17, 1183.22, 1183.22, 
18, 819.548, 819.548, 
19, 567.488, 567.488, 
20, 392.865, 392.865, 
21, 271.93, 271.93, 
22, 188.199, 188.199, 
23, 130.237, 130.237, 
24, 90.1205, 90.1205, 
25, 62.3574, 62.3574, 
26, 43.1455, 43.1455, 
27, 29.8517, 29.8517, 
28, 20.6535, 20.6535, 
29, 14.2893, 14.2893, 
30, 9.88602, 9.88602, 
31, 6.83957, 6.83957, 
32, 4.73187, 4.73187, 
33, 3.27366, 3.27366, 
34, 2.26482, 2.26482, 
35, 1.56687, 1.56687, 
36, 1.084, 1.084, 
37, 0.749941, 0.749941, 
38, 0.518828, 0.518828, 
39, 0.358938, 0.358938, 
40, 0.248322, 0.248322, 
41, 0.171795, 0.171795, 
42, 0.118852, 0.118852, 
43, 0.0822243, 0.0822243, 
44, 0.0568846, 0.0568846, 
45, 0.0393541, 0.0393541, 
46, 0.027226, 0.027226, 
47, 0.0188356, 0.0188356, 
48, 0.0130309, 0.0130309, 
49, 0.00901505, 0.00901505, 
50, 0.00623682, 0.00623682, 
51, 0.00431477, 0.00431477, 
52, 0.00298505, 0.00298505, 
53, 0.00206513, 0.00206513, 
54, 0.0014287, 0.0014287, 
55, 0.000988407, 0.000988407, 
56, 0.000683802, 0.000683802, 
57, 0.00047307, 0.00047307, 
58, 0.00032728, 0.00032728, 
59, 0.00022642, 0.00022642, 
60, 0.000156642, 0.000156642, 
61, 0.000108369, 0.000108369, 
62, 7.49718e-05, 7.49718e-05, 
63, 5.18672e-05, 5.18672e-05, 
64, 3.58829e-05, 3.58829e-05, 
```

## 対称ガウスザイデル
ほぼ一致
```
反復回数, 対称ガウスザイデル, cuthill-mckee 対称ガウスザイデル
0, 641281.0, 641281.0, 
1, 254789.0, 255984.0, 
2, 127014.0, 127156.0, 
3, 64478.7, 64519.0, 
4, 32834.8, 32851.2, 
5, 16733.0, 16740.7, 
6, 8529.25, 8533.04, 
7, 4347.92, 4349.83, 
8, 2216.48, 2217.45, 
9, 1129.92, 1130.42, 
10, 576.014, 576.268, 
11, 293.642, 293.771, 
12, 149.693, 149.759, 
13, 76.3105, 76.3443, 
14, 38.9015, 38.9188, 
15, 19.8312, 19.84, 
16, 10.1095, 10.114, 
17, 5.15361, 5.15589, 
18, 2.6272, 2.62836, 
19, 1.33929, 1.33988, 
20, 0.682739, 0.683041, 
21, 0.348045, 0.348199, 
22, 0.177426, 0.177504, 
23, 0.0904476, 0.0904877, 
24, 0.0461082, 0.0461286, 
25, 0.0235049, 0.0235153, 
26, 0.0119823, 0.0119876, 
27, 0.0061083, 0.00611101, 
28, 0.00311387, 0.00311525, 
29, 0.00158738, 0.00158809, 
30, 0.000809213, 0.000809571, 
31, 0.000412519, 0.000412701, 
32, 0.000210293, 0.000210386, 
33, 0.000107203, 0.00010725, 
34, 5.46495e-05, 5.46737e-05, 
35, 2.78591e-05, 2.78714e-05, 
36, 1.42019e-05, 1.42082e-05, 
37, 7.23983e-06, 7.24304e-06, 
38, 3.6907e-06, 3.69234e-06, 
39, 1.88144e-06, 1.88227e-06, 
40, 9.59115e-07, 9.5954e-07, 
41, 4.88935e-07, 4.89152e-07, 
42, 2.49248e-07, 2.49359e-07, 
43, 1.27061e-07, 1.27118e-07, 
44, 6.4773e-08, 6.48017e-08, 
45, 3.30198e-08, 3.30344e-08, 
46, 1.68328e-08, 1.68402e-08, 
47, 8.58097e-09, 8.58477e-09, 
48, 4.37438e-09, 4.37632e-09, 
49, 2.22996e-09, 2.23095e-09, 
50, 1.13679e-09, 1.13729e-09, 
51, 5.79508e-10, 5.79765e-10, 
52, 2.9542e-10, 2.95551e-10, 
53, 1.50599e-10, 1.50665e-10, 
54, 7.67718e-11, 7.68058e-11, 
55, 3.91366e-11, 3.91539e-11, 
56, 1.99509e-11, 1.99598e-11, 
57, 1.01705e-11, 1.01751e-11, 
58, 5.18472e-12, 5.18701e-12, 
59, 2.64305e-12, 2.64422e-12, 
60, 1.34737e-12, 1.34797e-12, 
61, 6.86859e-13, 6.87163e-13, 
62, 3.50145e-13, 3.50301e-13, 
63, 1.78496e-13, 1.78576e-13, 
64, 9.09935e-14, 9.10339e-14, 
```