### PR TITLE
CuthillMckeeを使用した対称ガウスザイデルの反復計算の際の要素に漏れがあったため修正しました

### DIFF
--- a/Abmc/SymGS.hpp
+++ b/Abmc/SymGS.hpp
@@ -290,7 +290,7 @@ static void SymmetryGaussSeidelForCuthillMckee(const Matrix& A, const Vector& b,
 		}
 
 		// 逆順
-		for(auto level = static_cast<std::make_signed_t<decltype(levelCount)>>(levelCount - 1); level > 0; level--)
+		for(auto level = static_cast<std::make_signed_t<decltype(levelCount)>>(levelCount - 1); level >= 0; level--)
 		{
 			for(auto idx = offset[level]; idx < offset[level+1]; idx++) // 同じレベル内では、依存関係はないのでここは逆順にする必要がない
 			{


### PR DESCRIPTION
@LWisteria 
こちらのプルリクエストで差があることにやはり違和感がありコードを見直しているとバグを見つけたので修正しました。確認よろしくお願いします
この修正を加えることによって完全に一致します。

```
反復回数, 対称ガウスザイデル, cuthill-mckee 対称ガウスザイデル
0,641281,641281, 
1,254789,254789, 
2,127014,127014, 
3,64478.7,64478.7, 
4,32834.8,32834.8,
5,16733,16733,
6,8529.25,8529.25,
7,4347.92,4347.92,
8,2216.48,2216.48,
9,1129.92,1129.92,
10,576.014,576.014,
11,293.642,293.642,
12,149.693,149.693,
13,76.3105,76.3105,
14,38.9015,38.9015,
15,19.8312,19.8312,
16,10.1095,10.1095,
17,5.15361,5.15361,
18,2.6272,2.6272,
19,1.33929,1.33929,
20,0.682739,0.682739,
21,0.348045,0.348045,
22,0.177426,0.177426,
23,0.0904476,0.0904476,
24,0.0461082,0.0461082,
25,0.0235049,0.0235049,
26,0.0119823,0.0119823,
27,0.0061083,0.0061083,
28,0.00311387,0.00311387,
29,0.00158738,0.00158738,
30,0.000809213,0.000809213,
31,0.000412519,0.000412519,
32,0.000210293,0.000210293,
33,0.000107203,0.000107203,
34,5.46E-05,5.46E-05,
35,2.79E-05,2.79E-05,
36,1.42E-05,1.42E-05,
37,7.24E-06,7.24E-06,
38,3.69E-06,3.69E-06,
39,1.88E-06,1.88E-06,
40,9.59E-07,9.59E-07,
41,4.89E-07,4.89E-07,
42,2.49E-07,2.49E-07,
43,1.27E-07,1.27E-07,
44,6.48E-08,6.48E-08,
45,3.30E-08,3.30E-08,
46,1.68E-08,1.68E-08,
47,8.58E-09,8.58E-09,
48,4.37E-09,4.37E-09,
49,2.23E-09,2.23E-09,
50,1.14E-09,1.14E-09,
51,5.80E-10,5.80E-10,
52,2.95E-10,2.95E-10,
53,1.51E-10,1.51E-10,
54,7.68E-11,7.68E-11,
55,3.91E-11,3.91E-11,
56,2.00E-11,2.00E-11,
57,1.02E-11,1.02E-11,
58,5.18E-12,5.18E-12,
59,2.64E-12,2.64E-12,
60,1.35E-12,1.35E-12,
61,6.87E-13,6.87E-13,
62,3.50E-13,3.50E-13,
63,1.78E-13,1.78E-13,
64,9.10E-14,9.10E-14,
```